### PR TITLE
Fix "subscript contains invalid names" error by removing all instances of shuffled sequences

### DIFF
--- a/R/motif_enrichment.R
+++ b/R/motif_enrichment.R
@@ -57,7 +57,7 @@ motif_enrichment <- function(peak_input,
 
   seq_path <- file.path(out_dir, "sequences.tsv")
   seq <- utils::read.table(seq_path, header = TRUE)
-  cleaned_ids <- seq$seq_ID[!grepl("_shuf_1", seq$seq_ID)]
+  cleaned_ids <- seq$seq_ID[!grepl("_shuf_", seq$seq_ID)]
 
   return(
     list(


### PR DESCRIPTION
Fixed #3 

Remove all instances of sequences ending with `_shuf_N` where `N` is any integer rather than just those ending with `_shuf_1`.